### PR TITLE
Bugfix in DiagnosisResults

### DIFF
--- a/inspectit.server/src/main/java/rocks/inspectit/server/diagnosis/results/DiagnosisResults.java
+++ b/inspectit.server/src/main/java/rocks/inspectit/server/diagnosis/results/DiagnosisResults.java
@@ -33,7 +33,7 @@ public class DiagnosisResults implements IDiagnosisResults<ProblemOccurrence> {
 	 */
 	@Override
 	public final Set<ProblemOccurrence> getDiagnosisResults() {
-		return this.resultingSet.getHashSetCopy();
+		return this.resultingSet;
 	}
 
 }


### PR DESCRIPTION
DiagnosisResults is returning a new HashSet object for each execution.